### PR TITLE
chore(routes): remove unused metrics import

### DIFF
--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -9,8 +9,6 @@ import {
   validateRoomTopic,
 } from "./middleware/ValidationMiddleware";
 import { AuthController } from "./controllers/AuthController";
-import { metricsEndpoint } from "./metrics";
-
 export const frontendUrl = process.env.FRONTEND_URL || "http://localhost:5173";
 // export const frontendUrl = 'http://localhost:5173'
 


### PR DESCRIPTION
- Removed the import statement for metricsEndpoint from routes.ts.

This change cleans up the code by eliminating an unused import, which helps maintain clarity and reduces potential confusion in the routes file.